### PR TITLE
Fix isLinear with symbolic coefficients

### DIFF
--- a/nerdamer.core.js
+++ b/nerdamer.core.js
@@ -4264,6 +4264,8 @@ var nerdamer = (function (imports) {
         isLinear: function (wrt) {
             if (wrt) {
                 if (this.isConstant()) return true;
+                // If this symbol doesn't contain the variable (including in exponents), it's constant with respect to it
+                if (!this.contains(wrt, true)) return true;
                 if (this.group === S) {
                     if (this.value === wrt) return this.power.equals(1);
                     else return true;
@@ -4276,7 +4278,11 @@ var nerdamer = (function (imports) {
                     return true;
                 }
 
-                if (this.group === CB && this.symbols[wrt]) return this.symbols[wrt].isLinear(wrt);
+                if (this.group === CB) {
+                    // If the variable doesn't exist in this term, it's constant wrt that variable, hence linear
+                    if (!this.symbols[wrt]) return true;
+                    return this.symbols[wrt].isLinear(wrt);
+                }
                 return false;
             } else return this.power.equals(1);
         },

--- a/spec/coeffs-irrational.spec.js
+++ b/spec/coeffs-irrational.spec.js
@@ -185,114 +185,114 @@ describe('Coefficients with irrational constants', function () {
          */
 
         describe('single terms with symbolic coefficients', function () {
-            xit('should recognize pi*x as linear in x', function () {
+            it('should recognize pi*x as linear in x', function () {
                 expect(nerdamer('pi*x').symbol.isLinear('x')).toBe(true);
             });
 
-            xit('should recognize pi*x as linear in y (does not contain y)', function () {
+            it('should recognize pi*x as linear in y (does not contain y)', function () {
                 expect(nerdamer('pi*x').symbol.isLinear('y')).toBe(true);
             });
 
-            xit('should recognize e*y as linear in y', function () {
+            it('should recognize e*y as linear in y', function () {
                 expect(nerdamer('e*y').symbol.isLinear('y')).toBe(true);
             });
 
-            xit('should recognize e*y as linear in x (does not contain x)', function () {
+            it('should recognize e*y as linear in x (does not contain x)', function () {
                 expect(nerdamer('e*y').symbol.isLinear('x')).toBe(true);
             });
 
-            xit('should recognize a*x as linear in x', function () {
+            it('should recognize a*x as linear in x', function () {
                 expect(nerdamer('a*x').symbol.isLinear('x')).toBe(true);
             });
 
-            xit('should recognize sqrt(2)*x as linear in x', function () {
+            it('should recognize sqrt(2)*x as linear in x', function () {
                 expect(nerdamer('sqrt(2)*x').symbol.isLinear('x')).toBe(true);
             });
         });
 
         describe('multi-term expressions with symbolic coefficients', function () {
-            xit('should recognize a*x + b*y as linear in x', function () {
+            it('should recognize a*x + b*y as linear in x', function () {
                 expect(nerdamer('a*x+b*y').symbol.isLinear('x')).toBe(true);
             });
 
-            xit('should recognize a*x + b*y as linear in y', function () {
+            it('should recognize a*x + b*y as linear in y', function () {
                 expect(nerdamer('a*x+b*y').symbol.isLinear('y')).toBe(true);
             });
 
-            xit('should recognize pi*x + e*y as linear in x', function () {
+            it('should recognize pi*x + e*y as linear in x', function () {
                 expect(nerdamer('pi*x+e*y').symbol.isLinear('x')).toBe(true);
             });
 
-            xit('should recognize pi*x + e*y as linear in y', function () {
+            it('should recognize pi*x + e*y as linear in y', function () {
                 expect(nerdamer('pi*x+e*y').symbol.isLinear('y')).toBe(true);
             });
 
-            xit('should recognize pi*x + e*y - sqrt(2) as linear in x', function () {
+            it('should recognize pi*x + e*y - sqrt(2) as linear in x', function () {
                 expect(nerdamer('pi*x+e*y-sqrt(2)').symbol.isLinear('x')).toBe(true);
             });
 
-            xit('should recognize pi*x + e*y - sqrt(2) as linear in y', function () {
+            it('should recognize pi*x + e*y - sqrt(2) as linear in y', function () {
                 expect(nerdamer('pi*x+e*y-sqrt(2)').symbol.isLinear('y')).toBe(true);
             });
 
-            xit('should recognize sqrt(2)*x + sqrt(3)*y + 1 as linear in x and y', function () {
+            it('should recognize sqrt(2)*x + sqrt(3)*y + 1 as linear in x and y', function () {
                 expect(nerdamer('sqrt(2)*x+sqrt(3)*y+1').symbol.isLinear('x')).toBe(true);
                 expect(nerdamer('sqrt(2)*x+sqrt(3)*y+1').symbol.isLinear('y')).toBe(true);
             });
         });
 
         describe('non-linear expressions should still return false', function () {
-            xit('should recognize x^2 as not linear in x', function () {
+            it('should recognize x^2 as not linear in x', function () {
                 expect(nerdamer('x^2').symbol.isLinear('x')).toBe(false);
             });
 
-            xit('should recognize sin(x) as not linear in x', function () {
+            it('should recognize sin(x) as not linear in x', function () {
                 expect(nerdamer('sin(x)').symbol.isLinear('x')).toBe(false);
             });
 
-            xit('should recognize x^2 + y as not linear in x', function () {
+            it('should recognize x^2 + y as not linear in x', function () {
                 expect(nerdamer('x^2+y').symbol.isLinear('x')).toBe(false);
             });
 
-            xit('should recognize x^2 + y as linear in y', function () {
+            it('should recognize x^2 + y as linear in y', function () {
                 expect(nerdamer('x^2+y').symbol.isLinear('y')).toBe(true);
             });
 
-            xit('should recognize e^x as not linear in x (exponential)', function () {
+            it('should recognize e^x as not linear in x (exponential)', function () {
                 expect(nerdamer('e^x').symbol.isLinear('x')).toBe(false);
             });
 
-            xit('should recognize e^x + y as not linear in x', function () {
+            it('should recognize e^x + y as not linear in x', function () {
                 expect(nerdamer('e^x+y').symbol.isLinear('x')).toBe(false);
             });
 
-            xit('should recognize e^x + y as linear in y', function () {
+            it('should recognize e^x + y as linear in y', function () {
                 expect(nerdamer('e^x+y').symbol.isLinear('y')).toBe(true);
             });
 
-            xit('should recognize 2^x as not linear in x', function () {
+            it('should recognize 2^x as not linear in x', function () {
                 expect(nerdamer('2^x').symbol.isLinear('x')).toBe(false);
             });
 
-            xit('should recognize x^x as not linear in x', function () {
+            it('should recognize x^x as not linear in x', function () {
                 expect(nerdamer('x^x').symbol.isLinear('x')).toBe(false);
             });
         });
 
         describe('terms not containing the variable should be considered linear', function () {
-            xit('should recognize sqrt(2) as linear in x (does not contain x)', function () {
+            it('should recognize sqrt(2) as linear in x (does not contain x)', function () {
                 expect(nerdamer('sqrt(2)').symbol.isLinear('x')).toBe(true);
             });
 
-            xit('should recognize sin(a) as linear in x (does not contain x)', function () {
+            it('should recognize sin(a) as linear in x (does not contain x)', function () {
                 expect(nerdamer('sin(a)').symbol.isLinear('x')).toBe(true);
             });
 
-            xit('should recognize e^a as linear in x (does not contain x)', function () {
+            it('should recognize e^a as linear in x (does not contain x)', function () {
                 expect(nerdamer('e^a').symbol.isLinear('x')).toBe(true);
             });
 
-            xit('should recognize e^x as linear in y (does not contain y)', function () {
+            it('should recognize e^x as linear in y (does not contain y)', function () {
                 expect(nerdamer('e^x').symbol.isLinear('y')).toBe(true);
             });
         });


### PR DESCRIPTION
## Commit 1: `e5b87c6` - Test Setup
**"test: add skipped regression tests for isLinear with symbolic coefficients"**

Added 130 lines of new regression tests to coeffs-irrational.spec.js for the `isLinear()` function. These tests were marked as pending (`xit`) because they exposed bugs in handling:
- CB group terms that don't contain the target variable
- Terms without the target variable (e.g., checking if `sqrt(2)` is linear in `x`)

## Commit 2: `243b6b4` - Bug Fix
**"fix: isLinear() now correctly handles terms not containing the target variable"**

Fixed the `isLinear()` function in nerdamer.core.js to correctly return `true` for expressions that don't contain the variable being checked (since they're constant with respect to that variable).

**Key changes:**
- Added early return for symbols that don't contain the variable at all
- Fixed CB group handling to return `true` when the variable isn't in the term
- Enabled the previously skipped regression tests

**Examples of fixed cases:**
- `pi*x` checked for linearity in `y` → now correctly returns `true`
- `a*x + b*y` checked for linearity in `x` or `y` → now correctly returns `true`
- `sqrt(2)` checked for linearity in `x` → now correctly returns `true`