### PR TITLE
fix: remove redundant NerdamerSymbol wrapper in USE_BIG complex power calculation

### DIFF
--- a/nerdamer.core.js
+++ b/nerdamer.core.js
@@ -17090,11 +17090,9 @@ class Parser {
                     const im = symA.imagpart();
                     if (re.isConstant('all') && im.isConstant('all')) {
                         phi = Settings.USE_BIG
-                            ? new NerdamerSymbol(
-                                  nerdamerBigDecimal
-                                      .atan2(im.multiplier.toDecimal(), re.multiplier.toDecimal())
-                                      .times(symB.toString())
-                              )
+                            ? nerdamerBigDecimal
+                                  .atan2(im.multiplier.toDecimal(), re.multiplier.toDecimal())
+                                  .times(symB.toString())
                             : Math.atan2(Number(im.multiplier.toDecimal()), Number(re.multiplier.toDecimal())) *
                               Number(symB.multiplier.toDecimal());
                         theta = new NerdamerSymbol(phi);

--- a/spec/use-big-complex-pow.spec.js
+++ b/spec/use-big-complex-pow.spec.js
@@ -1,0 +1,89 @@
+/* global expect, describe, it, beforeEach, afterEach */
+
+/**
+ * Regression tests for USE_BIG mode with complex number powers.
+ *
+ * These tests verify the fix for a bug in the pow() function where the bigDec.atan2() result was double-wrapped with NerdamerSymbol when USE_BIG was enabled.
+ *
+ * The buggy code was: phi = Settings.USE_BIG ? new NerdamerSymbol(bigDec.atan2(...).times(b.toString())) // BUG: wrapped here : Math.atan2(...) * b; theta = new NerdamerSymbol(phi); // and wrapped again here
+ *
+ * The bug caused: "ParseError: Invalid integer: NaN" because a NerdamerSymbol containing a Decimal was passed to new NerdamerSymbol() again.
+ *
+ * Fix: Removed the redundant new NerdamerSymbol() wrapper from the USE_BIG branch, so phi is just the raw Decimal value which then gets properly wrapped once on the next line.
+ */
+
+const nerdamer = require('../nerdamer.core.js');
+const core = nerdamer.getCore();
+const { Settings } = core;
+
+describe('USE_BIG mode with complex number powers', () => {
+    let originalUseBig;
+
+    beforeEach(() => {
+        // Save original setting
+        originalUseBig = Settings.USE_BIG;
+    });
+
+    afterEach(() => {
+        // Restore original setting
+        Settings.USE_BIG = originalUseBig;
+    });
+
+    describe('when USE_BIG is false (default)', () => {
+        beforeEach(() => {
+            Settings.USE_BIG = false;
+        });
+
+        it('should compute i^3 correctly', () => {
+            const result = nerdamer('i^3').evaluate().text('decimals');
+            // I^3 = i^2 * i = -1 * i = -i
+            expect(result).toEqual('-i');
+        });
+
+        it('should compute i^4 correctly', () => {
+            const result = nerdamer('i^4').evaluate().text('decimals');
+            // I^4 = (i^2)^2 = (-1)^2 = 1
+            expect(result).toEqual('1');
+        });
+    });
+
+    describe('when USE_BIG is true', () => {
+        beforeEach(() => {
+            Settings.USE_BIG = true;
+        });
+
+        it('should compute i^3 correctly in USE_BIG mode', () => {
+            const result = nerdamer('i^3').evaluate().text('decimals');
+            // I^3 = i^2 * i = -1 * i = -i
+            expect(result).toEqual('-i');
+        });
+
+        it('should compute i^4 correctly in USE_BIG mode', () => {
+            const result = nerdamer('i^4').evaluate().text('decimals');
+            // I^4 = (i^2)^2 = (-1)^2 = 1
+            expect(result).toEqual('1');
+        });
+
+        it('should handle pure imaginary number powers in USE_BIG mode', () => {
+            // 2i raised to power 2 = 4*i^2 = -4 (real only, no imaginary component)
+            const result = nerdamer('(2*i)^2').evaluate().text('decimals');
+            // Result should be exactly -4 with no imaginary part
+            expect(result).toMatch(/^-4(?:\.\d+)?$/u);
+        });
+
+        it('should handle pure imaginary number cubed in USE_BIG mode', () => {
+            // (2i)^3 = 8*i^3 = 8*(-i) = -8i (pure imaginary, no real component)
+            const result = nerdamer('(2*i)^3').evaluate().text('decimals');
+            // Result should be -8*i with no real part (or negligible real part from floating point)
+            // Matches: "-8*i" or "-0.0000000000000009382-8*i" (negligible real part with 10+ leading zeros)
+            expect(result).toMatch(/^(?:-?0\.0{10,}\d*)?-8(?:\.\d+)?\*i$/u);
+        });
+
+        it('should handle pure imaginary number to the 4th power in USE_BIG mode', () => {
+            // (2i)^4 = 16*i^4 = 16*1 = 16 (real only, no imaginary component)
+            const result = nerdamer('(2*i)^4').evaluate().text('decimals');
+            // Result should be exactly 16 with no imaginary part
+            expect(result).toMatch(/^16(?:\.\d+)?$/u);
+        });
+    });
+});


### PR DESCRIPTION
## Summary

#74 (from copilot report)

Fix bug in `pow()` function where the `bigDec.atan2()` result was double-wrapped with `NerdamerSymbol` when computing powers of imaginary numbers with `Settings.USE_BIG` enabled.

## Bug Description

When `USE_BIG` is enabled and computing powers of complex/imaginary numbers like `(2*i)^2`, the code caused:

```
ParseError: Invalid integer: NaN
```

## Root Cause

The `pow()` function had:
```javascript
phi = Settings.USE_BIG
    ? new NerdamerSymbol(bigDec.atan2(...).times(b.toString()))  // wrapped here
    : Math.atan2(...) * b;
theta = new NerdamerSymbol(phi);  // and wrapped again here
```

The `phi` value was wrapped in `NerdamerSymbol` twice - once in the ternary expression and again on the next line. Passing a `NerdamerSymbol` containing a `Decimal` to `new NerdamerSymbol()` again resulted in `NaN`.

## Fix

Remove the redundant `new NerdamerSymbol()` wrapper from the USE_BIG branch, so `phi` is just the raw `Decimal` value which then gets properly wrapped once on the next line.

## Testing

- Added regression tests in `spec/use-big-complex-pow.spec.js`
- All 279 existing specs pass