### PR TITLE
Fix bug with LaTeX output of operators in log #83

### DIFF
--- a/nerdamer.core.js
+++ b/nerdamer.core.js
@@ -128,6 +128,7 @@ var nerdamer = (function (imports) {
         PI: Math.PI,
         E: Math.E,
         LOG: 'log',
+        LOG_LATEX: 'log',
         LOG10: 'log10',
         LOG10_LATEX: 'log_{10}',
         LOG2: 'log2',
@@ -7459,6 +7460,8 @@ var nerdamer = (function (imports) {
                             f = LaTeX.brackets(this.toTeX(e.args), 'abs');
                         } else if (fname === PARENTHESIS) {
                             f = LaTeX.brackets(this.toTeX(e.args), 'parens');
+                        } else if (fname == Settings.LOG) {
+                            f = '\\' + Settings.LOG_LATEX + '\\left( ' + this.toTeX(e.args) + '\\right)'; 
                         } else if (fname === Settings.LOG10) {
                             f = '\\' + Settings.LOG10_LATEX + '\\left( ' + this.toTeX(e.args) + '\\right)';
                         } else if (fname === Settings.LOG2) {

--- a/spec/LaTeX.spec.js
+++ b/spec/LaTeX.spec.js
@@ -332,4 +332,25 @@ describe('TeX features', function () {
             expect(teX).toEqual(testCases[i].expected);
         }
     });
+
+    it('should handle operators in log with different bases', function() {
+        const testCases = [
+            {
+                given: 'log10(10*x)',
+                expected: '\\log_{10}\\left( 10 \\cdot x\\right)'
+            },
+            {
+                given: 'ln(10*x)',
+                expected: '\\ln \\left(10 \\cdot x\\right)'
+            },
+            {
+                given: 'log(10*x)',
+                expected: '\\log\\left( 10 \\cdot x\\right)'
+            }
+        ]
+        for (var i = 0; i < testCases.length; ++i) {
+            const output = nerdamer.convertToLaTeX(testCases[i].given);
+            expect(output).toEqual(testCases[i].expected);            
+        }
+    });
 });


### PR DESCRIPTION
This fixes #83 which is about a bug in the LaTeX output of operators in log.

- I have added a new field `LOG_LATEX` to the Settings similar to the existing field `LOG10_LATEX`.

- A new unit test has been added for the issue.

Let me know if there are things that should be done differently.