### PR TITLE
Fix vector*vector multiplication to compute dot product

### DIFF
--- a/nerdamer.core.js
+++ b/nerdamer.core.js
@@ -16831,12 +16831,10 @@ class Parser {
             } else if (isVector(a) && isVector(b)) {
                 const aVec = /** @type {VectorType} */ (a);
                 const bVec = /** @type {VectorType} */ (b);
-                bVec.each((el, idx) => {
-                    idx--;
-                    bVec.elements[idx] = /** @type {NerdamerSymbolType} */ (
-                        _.multiply(aVec.elements[idx], bVec.elements[idx])
-                    );
-                });
+                if (aVec.elements.length === bVec.elements.length) {
+                    return /** @type {NerdamerSymbolType} */ (aVec.dot(bVec));
+                }
+                err('Dimensions must match!');
             } else if (isVector(a) && isMatrix(b)) {
                 // Try to convert a to a matrix
                 return this.multiply(b, a);

--- a/spec/core.spec.js
+++ b/spec/core.spec.js
@@ -1808,7 +1808,7 @@ describe('Nerdamer core', () => {
     it('should multiply vectors correctly', () => {
         expect(nerdamer('3*[a,b]').toString()).toEqual('[3*a,3*b]');
         expect(nerdamer('[a,b]*x').toString()).toEqual('[a*x,b*x]');
-        expect(nerdamer('[a,b]*[a,b]').toString()).toEqual('[a^2,b^2]');
+        expect(nerdamer('[a,b]*[a,b]').toString()).toEqual('a^2+b^2');
     });
     it('should cross-multiply vectors correctly', () => {
         expect(nerdamer('cross([1,2,3],[4,5,6])').toString()).toEqual('[-3,6,-3]');


### PR DESCRIPTION
## Summary
- The `*` operator between two vectors was multiplying elements component-wise (e.g. `[a,b]*[a,b]` → `[a^2,b^2]`), instead of computing the dot product as it should for vector*vector multiplication.
- This was inconsistent with the documented `Vector.multiply(scalar)` API (which only takes a scalar) and with the standalone `dot()` parser function, which already computed the dot product correctly.
- Fixed the `isVector(a) && isVector(b)` branch in `Parser.multiply` (`nerdamer.core.js`) to return `aVec.dot(bVec)`, erroring on dimension mismatch, consistent with the matrix/vector multiply branches nearby.
- Updated the test that had encoded the old (buggy) component-wise behavior as the expected result.

## Test plan
- [x] `npx jasmine` — 280 specs, 0 failures
- [x] `npx jest` — 64 tests passed
- [x] `npx tsc --noEmit` (both tsconfigs) — no errors
- [x] `npx eslint` / `npx prettier --check` — clean
- [x] Manual check: `nerdamer('[1,2,3]*[4,5,6]').toString()` → `32` (correct dot product)