### PR TITLE
Add closed-form symbolic summation to sum()

### DIFF
--- a/Calculus.js
+++ b/Calculus.js
@@ -482,6 +482,95 @@ if (typeof module !== 'undefined' && nerdamer === undefined) {
         return retval;
     });
 
+    /**
+     * Attempts to reduce a single (non-additive) term to a closed form for sum(term, indexName, 1, n), by pulling out
+     * any constant factor (Constant Multiple Rule) and applying the standard closed-form formula for the remaining
+     * power of the index. Returns null when the term isn't a supported shape (i.e. isn't a constant, or a constant
+     * times index^1, index^2 or index^3).
+     *
+     * @param {NerdamerSymbolType} term
+     * @param {string} indexName
+     * @param {NerdamerSymbolType} n
+     * @returns {NerdamerSymbolType | null}
+     */
+    function closedFormSumOfTerm(term, indexName, n) {
+        // Constant: sum(c, i, 1, n) = c*n
+        if (!term.contains(indexName)) {
+            return /** @type {NerdamerSymbolType} */ (_.multiply(term.clone(), n.clone()));
+        }
+
+        // Determine what power of the index this term carries, so we know which closed-form formula applies
+        let power = null;
+        if (term.group === S && term.value === indexName) {
+            power = Number(term.power);
+        } else if (term.group === CB) {
+            term.each(factor => {
+                if (power === null && factor.group === S && factor.value === indexName) {
+                    power = Number(factor.power);
+                }
+            });
+        }
+
+        if (power === null || !isInt(power) || power < 1 || power > 3) {
+            return null;
+        }
+
+        // Constant Multiple Rule: pull the remaining factors out as a constant coefficient
+        const coefficient = /** @type {NerdamerSymbolType} */ (
+            _.divide(
+                term.clone(),
+                /** @type {NerdamerSymbolType} */ (_.pow(new NerdamerSymbol(indexName), new NerdamerSymbol(power)))
+            )
+        );
+        if (coefficient.contains(indexName)) {
+            return null;
+        }
+
+        let closedForm;
+        if (power === 1) {
+            closedForm = _.parse(format('(({0})*(({0})+1))/2', n));
+        } else if (power === 2) {
+            closedForm = _.parse(format('(({0})*(({0})+1)*(2*({0})+1))/6', n));
+        } else {
+            closedForm = _.parse(format('((({0})*(({0})+1))/2)^2', n));
+        }
+
+        return /** @type {NerdamerSymbolType} */ (_.multiply(coefficient, closedForm));
+    }
+
+    /**
+     * Attempts to compute a closed form for sum(fn, indexName, 1, n) using the Sum Rule to split fn into terms and
+     * closedFormSumOfTerm to resolve each term. Returns null if any term isn't a supported closed form, in which case
+     * the sum is left unevaluated.
+     *
+     * @param {NerdamerSymbolType} fn
+     * @param {string} indexName
+     * @param {NerdamerSymbolType} n
+     * @returns {NerdamerSymbolType | null}
+     */
+    function closedFormSum(fn, indexName, n) {
+        // Sum Rule: sum(f+g, i, 1, n) = sum(f, i, 1, n) + sum(g, i, 1, n)
+        if (fn.group === CP || fn.group === PL) {
+            let result = new NerdamerSymbol(0);
+            let unresolved = false;
+            fn.each(term => {
+                if (unresolved) {
+                    return;
+                }
+                const termSum = closedFormSumOfTerm(term, indexName, n);
+                if (termSum === null) {
+                    unresolved = true;
+                    return;
+                }
+                result = /** @type {NerdamerSymbolType} */ (_.add(result, termSum));
+            }, true);
+
+            return unresolved ? null : result;
+        }
+
+        return closedFormSumOfTerm(fn, indexName, n);
+    }
+
     core.Settings.integration_depth = 10;
 
     core.Settings.max_lim_depth = 10;
@@ -524,6 +613,12 @@ if (typeof module !== 'undefined' && nerdamer === undefined) {
                     }
                     return result;
                 });
+            } else if (core.Utils.isNumericSymbol(start) && Number(start) === 1) {
+                const closedForm = closedFormSum(fn, indexName, end);
+                retval =
+                    closedForm === null
+                        ? _.symfunction('sum', [fn, new NerdamerSymbol(indexName), start, end])
+                        : closedForm;
             } else {
                 retval = _.symfunction('sum', [fn, new NerdamerSymbol(indexName), start, end]);
             }

--- a/spec/calculus.spec.js
+++ b/spec/calculus.spec.js
@@ -120,6 +120,33 @@ describe('Calculus', () => {
         expect(round(nerdamer('sum(e^(-x^2*π/9),x,1,100)').evaluate(), 10)).toEqual(round(1.0, 10));
     });
 
+    it('should calculate symbolic sums with a symbolic upper bound correctly', () => {
+        // Standard closed-form formulas
+        expect(nerdamer('sum(5, x, 1, n)').toString()).toEqual('5*n');
+        expect(nerdamer('sum(x, x, 1, n)').toString()).toEqual('(1/2)*(1+n)*n');
+        expect(nerdamer('sum(x^2, x, 1, n)').toString()).toEqual('(1/6)*(1+2*n)*(1+n)*n');
+        expect(nerdamer('sum(x^3, x, 1, n)').toString()).toEqual('(1/4)*((1+n)*n)^2');
+
+        // Constant Multiple Rule
+        expect(nerdamer('sum(2*x, x, 1, n)').toString()).toEqual('(1+n)*n');
+        expect(nerdamer('sum(3*x^2, x, 1, n)').toString()).toEqual('(1/2)*(1+2*n)*(1+n)*n');
+
+        // Sum Rule combined with the closed-form formulas above
+        expect(nerdamer('sum(x^2+x, x, 1, n)').toString()).toEqual('(1/2)*(1+n)*n+(1/6)*(1+2*n)*(1+n)*n');
+        expect(nerdamer('sum(x^2+3*x+2, x, 1, n)').toString()).toEqual('(1/6)*(1+2*n)*(1+n)*n+(3/2)*(1+n)*n+2*n');
+
+        // Verify the closed forms against direct numerical evaluation
+        expect(nerdamer('sum(x^2+3*x+2, x, 1, n)').evaluate({ n: 10 }).toString()).toEqual(nerdamer('sum(x^2+3*x+2, x, 1, 10)').evaluate().toString());
+
+        // A free variable unrelated to the index is treated as a constant factor
+        expect(nerdamer('sum(x^2*y+2*x, x, 1, n)').toString()).toEqual('(1+n)*n+(1/6)*(1+2*n)*(1+n)*n*y');
+
+        // Falls back to an unevaluated sum when no closed form applies
+        expect(nerdamer('sum(sin(x), x, 1, n)').toString()).toEqual('sum(sin(x),x,1,n)');
+        expect(nerdamer('sum(x^4, x, 1, n)').toString()).toEqual('sum(x^4,x,1,n)');
+        expect(nerdamer('sum(x, x, 2, n)').toString()).toEqual('sum(x,x,2,n)');
+    });
+
     it('should calculate the definite integral correctly', () => {
         expect(round(nerdamer('defint(cos(x),1,2,x)').evaluate(), 14)).toEqual(round(0.067826442018, 14));
         expect(round(nerdamer('defint(cos(x)^3*x^2-1,-1,9)').evaluate(), 14)).toEqual(round(8.543016466395, 14));


### PR DESCRIPTION
## Summary
- `sum(fn, index, start, end)` previously only evaluated numerically when both bounds were numeric, and otherwise returned the sum unevaluated when the upper bound was symbolic.
- When the lower bound is `1` and the upper bound is symbolic, the summand is now decomposed via the **Sum Rule** (splitting `sum(f+g)` into `sum(f)+sum(g)`) and the **Constant Multiple Rule** (pulling constant factors out of the sum), and each resulting term is resolved with the standard closed-form formulas:
  - `sum(c, i, 1, n) = c*n`
  - `sum(i, i, 1, n) = (n*(n+1))/2`
  - `sum(i^2, i, 1, n) = (n*(n+1)*(2n+1))/6`
  - `sum(i^3, i, 1, n) = ((n*(n+1))/2)^2`
- If any term doesn't fit a supported shape (e.g. `sin(x)`, `x^4`, or a lower bound other than `1`), the whole sum falls back to the previous unevaluated `sum(...)` symfunction, so no existing behavior changes.

## Test plan
- [x] Added `should calculate symbolic sums with a symbolic upper bound correctly` to `spec/calculus.spec.js`, covering constant/linear/quadratic/cubic closed forms, the Sum and Constant Multiple rules, a term with an unrelated free variable, cross-checking against direct numerical evaluation, and the unresolved fallback cases.
- [x] `npx jasmine` — 285 specs, 0 failures
- [x] `npx tsc --noEmit` and `npx tsc -p tsconfig.js.json --noEmit` — clean
- [x] `npx eslint Calculus.js spec/calculus.spec.js` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)